### PR TITLE
Adding missing include for ‘getcwd’ and ‘chdir’

### DIFF
--- a/src/WIIDisc.cpp
+++ b/src/WIIDisc.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <string>
 #include <ctype.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <fcntl.h>
 #include <openssl/ssl.h>


### PR DESCRIPTION
#### Problem

```
git clone git://github.com/jjgod/wiiscrubber-ng.git && cd wiiscrubber-ng && mkdir -p bin && cd bin && cmake .. && colormake

/home/user/repo/wiiscrubber-ng/src/WIIDisc.cpp:4215:31: error: ‘getcwd’ was not declared in this scope
/home/user/repo/wiiscrubber-ng/src/WIIDisc.cpp:4221:21: error: ‘chdir’ was not declared in this scope

cat /etc/issue
Ubuntu 12.10 \n \l
```
